### PR TITLE
Restore loop to slot fetcher

### DIFF
--- a/utils/slot.mjs
+++ b/utils/slot.mjs
@@ -4,46 +4,50 @@ import { createSolanaRpcSubscriptions_UNSTABLE } from "@solana/web3.js";
 
 const MAX_SLOT_FETCH_ATTEMPTS = process.env.MAX_SLOT_FETCH_ATTEMPTS || 100;
 let attempts = 0;
-const abortController = new AbortController();
 
 export const watchSlotSent = async (gSlotSent, rpcSubscriptions) => {
-  try {
-    const slotNotifications = await rpcSubscriptions
-      .slotsUpdatesNotifications()
-      .subscribe({ abortSignal: abortController.signal });
-
-    for await (const notification of slotNotifications) {
-      if (
-        notification.type === "firstShredReceived" ||
-        notification.type === "completed"
-      ) {
-        gSlotSent.value = notification.slot;
-        gSlotSent.updated_at = Date.now();
-        attempts = 0;
-        continue;
-      }
-
-      gSlotSent.value = null;
-      gSlotSent.updated_at = 0;
-
-      ++attempts;
-
-      if (attempts >= MAX_SLOT_FETCH_ATTEMPTS) {
-        console.log(
-          `ERROR: Max attempts for fetching slot type "firstShredReceived" or "completed" reached, exiting`
-        );
-        process.exit(0);
-      }
-
-      // If update not received in last 3s, re-subscribe
-      if (gSlotSent.value !== null) {
-        while (Date.now() - gSlotSent.updated_at < 3000) {
-          await sleep(1);
+  while (true) {
+    const abortController = new AbortController();
+    try {
+      const slotNotifications = await rpcSubscriptions
+        .slotsUpdatesNotifications()
+        .subscribe({ abortSignal: abortController.signal });
+  
+      for await (const notification of slotNotifications) {
+        if (
+          notification.type === "firstShredReceived" ||
+          notification.type === "completed"
+        ) {
+          gSlotSent.value = notification.slot;
+          gSlotSent.updated_at = Date.now();
+          attempts = 0;
+          continue;
+        }
+  
+        gSlotSent.value = null;
+        gSlotSent.updated_at = 0;
+  
+        ++attempts;
+  
+        if (attempts >= MAX_SLOT_FETCH_ATTEMPTS) {
+          console.log(
+            `ERROR: Max attempts for fetching slot type "firstShredReceived" or "completed" reached, exiting`
+          );
+          process.exit(0);
+        }
+  
+        // If update not received in last 3s, re-subscribe
+        if (gSlotSent.value !== null) {
+          while (Date.now() - gSlotSent.updated_at < 3000) {
+            await sleep(1);
+          }
         }
       }
+    } catch (e) {
+      console.log(`ERROR: ${e}`);
+      ++attempts;
+    } finally {
+      abortController.abort();
     }
-  } catch (e) {
-    console.log(`ERROR: ${e}`);
-    ++attempts;
   }
 };


### PR DESCRIPTION
This fetcher would exit, causing the rest of the program to hang indefinitely. This is because it was missing its retry `while (true)`.