### PR TITLE
Fix ping thing metrics registry exposure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,8 @@ mod tests {
     fn build_transaction_instructions_appends_signed_memo_instruction() {
         let wallet_pubkey = Pubkey::new_unique();
         let memo_string = "ping thing memo";
-        let instructions = build_transaction_instructions(&wallet_pubkey, 42, 20000, Some(memo_string));
+        let instructions =
+            build_transaction_instructions(&wallet_pubkey, 42, 20000, Some(memo_string));
 
         let memo_instruction = instructions.last().expect("memo instruction exists");
         assert_eq!(instructions.len(), 4);
@@ -103,7 +104,9 @@ mod tests {
 
 #[derive(Debug)]
 enum SendTransactionRequestError {
-    TransactionSerializationFailed { reason: String },
+    TransactionSerializationFailed {
+        reason: String,
+    },
     SendTransactionRequestFailed {
         endpoint: String,
         send_transaction_request_error: reqwest::Error,
@@ -127,7 +130,10 @@ enum SendTransactionRequestError {
         code: i64,
         message: String,
     },
-    SendTransactionResponseMissingSignature { endpoint: String, response_body: String },
+    SendTransactionResponseMissingSignature {
+        endpoint: String,
+        response_body: String,
+    },
     SendTransactionResponseSignatureMismatch {
         endpoint: String,
         expected_signature: String,
@@ -261,23 +267,24 @@ async fn send_transaction_using_configured_send_transaction_endpoint_or_rpc_clie
             .json(&request_body)
             .send()
             .await
-            .map_err(
-                |send_transaction_request_error| SendTransactionRequestError::SendTransactionRequestFailed {
+            .map_err(|send_transaction_request_error| {
+                SendTransactionRequestError::SendTransactionRequestFailed {
                     endpoint: send_transaction_endpoint_value.to_string(),
                     send_transaction_request_error,
-                },
-            )?;
+                }
+            })?;
 
         let response_status = response.status();
-        let response_body = response
-            .text()
-            .await
-            .map_err(
-                |send_transaction_response_read_error| SendTransactionRequestError::SendTransactionResponseReadFailed {
-                    endpoint: send_transaction_endpoint_value.to_string(),
-                    send_transaction_response_read_error,
-                },
-            )?;
+        let response_body =
+            response
+                .text()
+                .await
+                .map_err(|send_transaction_response_read_error| {
+                    SendTransactionRequestError::SendTransactionResponseReadFailed {
+                        endpoint: send_transaction_endpoint_value.to_string(),
+                        send_transaction_response_read_error,
+                    }
+                })?;
 
         if !response_status.is_success() {
             return Err(
@@ -307,11 +314,13 @@ async fn send_transaction_using_configured_send_transaction_endpoint_or_rpc_clie
                 .and_then(|value| value.as_str())
                 .unwrap_or("Unknown RPC error")
                 .to_string();
-            return Err(SendTransactionRequestError::SendTransactionResponseRpcError {
-                endpoint: send_transaction_endpoint_value.to_string(),
-                code: error_code,
-                message: error_message,
-            });
+            return Err(
+                SendTransactionRequestError::SendTransactionResponseRpcError {
+                    endpoint: send_transaction_endpoint_value.to_string(),
+                    code: error_code,
+                    message: error_message,
+                },
+            );
         }
 
         let response_signature = response_value
@@ -341,11 +350,11 @@ async fn send_transaction_using_configured_send_transaction_endpoint_or_rpc_clie
             .send_transaction_with_config(transaction, send_transaction_config)
             .await
             .map(|_| ())
-            .map_err(
-                |rpc_client_send_transaction_error| SendTransactionRequestError::RpcClientSendTransactionFailed {
+            .map_err(|rpc_client_send_transaction_error| {
+                SendTransactionRequestError::RpcClientSendTransactionFailed {
                     rpc_client_send_transaction_error,
-                },
-            )
+                }
+            })
     }
 }
 
@@ -619,7 +628,10 @@ async fn main() -> Result<()> {
 
     loop {
         if sleep_ms_loop > 0 {
-            info!("Sleeping {:?}ms before next transaction cycle", sleep_ms_loop);
+            info!(
+                "Sleeping {:?}ms before next transaction cycle",
+                sleep_ms_loop
+            );
             sleep_ms(sleep_ms_loop).await;
         }
 
@@ -797,7 +809,10 @@ async fn main() -> Result<()> {
         loop {
             // Check if timeout elapsed
             if start_time.elapsed() >= timeout_duration {
-                warn!("[TX] Transaction {:?} timed out after 20 seconds", signature);
+                warn!(
+                    "[TX] Transaction {:?} timed out after 20 seconds",
+                    signature
+                );
                 break;
             }
 
@@ -807,7 +822,10 @@ async fn main() -> Result<()> {
                     // Received a confirmation notification
                     if conf_signature == signature {
                         // This is the confirmation for our current transaction
-                        info!("[TX] Confirmation received for transaction: {:?}", signature);
+                        info!(
+                            "[TX] Confirmation received for transaction: {:?}",
+                            signature
+                        );
                         confirmed = true;
                         slot_landed = conf_slot_landed;
                         is_success = conf_success;
@@ -847,7 +865,8 @@ async fn main() -> Result<()> {
                         Ok(_) => {
                             debug!("[TX] Successfully resent transaction");
                         }
-                        Err(send_transaction_request_error) => match &send_transaction_request_error {
+                        Err(send_transaction_request_error) => match &send_transaction_request_error
+                        {
                             SendTransactionRequestError::SendTransactionRequestFailed {
                                 endpoint,
                                 send_transaction_request_error,

--- a/src/utils/blockhash.rs
+++ b/src/utils/blockhash.rs
@@ -61,62 +61,52 @@ pub async fn watch_blockhash(
         while let Some(message) = stream.next().await {
             match message {
                 Ok(msg) => {
-                    if let Some(update) = msg.update_oneof {
-                        match update {
-                            UpdateOneof::BlockMeta(block_meta_update) => {
-                                let blockhash_str = block_meta_update.blockhash;
-                                let block_height = block_meta_update
-                                    .block_height
-                                    .map(|bh| bh.block_height)
-                                    .unwrap_or(0);
+                    if let Some(UpdateOneof::BlockMeta(block_meta_update)) = msg.update_oneof {
+                        let blockhash_str = block_meta_update.blockhash;
+                        let block_height = block_meta_update
+                            .block_height
+                            .map(|bh| bh.block_height)
+                            .unwrap_or(0);
 
-                                // Parse blockhash from base58 string
-                                let hash_bytes = match bs58::decode(&blockhash_str).into_vec() {
-                                    Ok(decoded) => {
-                                        if decoded.len() == 32 {
-                                            match <[u8; 32]>::try_from(decoded.as_slice()) {
-                                                Ok(arr) => arr,
-                                                Err(_) => {
-                                                    error!(
-                                                        "[Blockhash Watcher] Failed to convert decoded blockhash to array for blockhash {:?} with length {:?}",
-                                                        blockhash_str, decoded.len()
-                                                    );
-                                                    continue;
-                                                }
-                                            }
-                                        } else {
+                        // Parse blockhash from base58 string
+                        let hash_bytes = match bs58::decode(&blockhash_str).into_vec() {
+                            Ok(decoded) => {
+                                if decoded.len() == 32 {
+                                    match <[u8; 32]>::try_from(decoded.as_slice()) {
+                                        Ok(arr) => arr,
+                                        Err(_) => {
                                             error!(
-                                                "[Blockhash Watcher] Decoded blockhash has wrong length: {:?} (expected 32)",
-                                                decoded.len()
+                                                "[Blockhash Watcher] Failed to convert decoded blockhash to array for blockhash {:?} with length {:?}",
+                                                blockhash_str, decoded.len()
                                             );
                                             continue;
                                         }
                                     }
-                                    Err(e) => {
-                                        error!(
-                                            "[Blockhash Watcher] Failed to decode blockhash: {:?}",
-                                            e
-                                        );
-                                        continue;
-                                    }
-                                };
-
-                                let new_hash = Hash::new_from_array(hash_bytes);
-
-                                // Update global blockhash if different
-                                let mut g = g_blockhash.lock().await;
-                                let previous_hash = g.value;
-
-                                if previous_hash != Some(new_hash) {
-                                    g.value = Some(new_hash);
-                                    g.last_valid_block_height = block_height;
-                                    g.updated_at = chrono::Utc::now().timestamp();
-                                    drop(g);
+                                } else {
+                                    error!(
+                                        "[Blockhash Watcher] Decoded blockhash has wrong length: {:?} (expected 32)",
+                                        decoded.len()
+                                    );
+                                    continue;
                                 }
                             }
-                            _ => {
-                                // Ignore other update types
+                            Err(e) => {
+                                error!("[Blockhash Watcher] Failed to decode blockhash: {:?}", e);
+                                continue;
                             }
+                        };
+
+                        let new_hash = Hash::new_from_array(hash_bytes);
+
+                        // Update global blockhash if different
+                        let mut g = g_blockhash.lock().await;
+                        let previous_hash = g.value;
+
+                        if previous_hash != Some(new_hash) {
+                            g.value = Some(new_hash);
+                            g.last_valid_block_height = block_height;
+                            g.updated_at = chrono::Utc::now().timestamp();
+                            drop(g);
                         }
                     }
                 }

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use warp::Filter;
 
 pub struct Metrics {
-    pub registry: Registry,
+    pub registry: Arc<Registry>,
     pub confirmation_latency: HistogramVec,
     pub slot_latency: HistogramVec,
 }
@@ -13,7 +13,7 @@ pub struct Metrics {
 impl Metrics {
     pub fn new() -> Result<Self> {
         info!("[Metrics] Initializing Prometheus metrics registry...");
-        let registry = Registry::new();
+        let registry = Arc::new(Registry::new());
 
         info!("[Metrics] Creating histogram buckets for confirmation latency...");
         // Generate millisecond buckets
@@ -76,7 +76,7 @@ impl Metrics {
             "[Metrics] Starting Prometheus metrics server on port {:?}...",
             port
         );
-        let metrics = Arc::new(self.registry.clone());
+        let metrics = Arc::clone(&self.registry);
 
         let metrics_route = warp::path!("metrics").map(move || {
             debug!("[Metrics] Handling /metrics request");
@@ -92,5 +92,25 @@ impl Metrics {
             port
         );
         warp::serve(metrics_route).run(([0, 0, 0, 0], port)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gathered_metrics_are_exposed_from_shared_registry() {
+        let metrics = Metrics::new().unwrap();
+        let mut buffer = Vec::new();
+        let encoder = prometheus::TextEncoder::new();
+
+        encoder
+            .encode(&metrics.registry.gather(), &mut buffer)
+            .unwrap();
+
+        let rendered = String::from_utf8(buffer).unwrap();
+        assert!(rendered.contains("ping_thing_client_confirmation_latency"));
+        assert!(rendered.contains("ping_thing_client_slot_latency"));
     }
 }

--- a/src/utils/priority_fees.rs
+++ b/src/utils/priority_fees.rs
@@ -115,7 +115,8 @@ pub async fn watch_prioritization_fees(
                 } else {
                     error!(
                         "[Priority Fees Watcher] RPC request to {:?} failed with status: {:?}",
-                        rpc_endpoint, response.status()
+                        rpc_endpoint,
+                        response.status()
                     );
                 }
             }

--- a/src/utils/subscription_manager.rs
+++ b/src/utils/subscription_manager.rs
@@ -58,38 +58,33 @@ pub async fn watch_transactions(
     while let Some(message) = stream.next().await {
         match message {
             Ok(msg) => {
-                if let Some(update) = msg.update_oneof {
-                    match update {
-                        UpdateOneof::Transaction(tx_update) => {
-                            if let Some(transaction) = tx_update.transaction {
-                                let tx_signature =
-                                    bs58::encode(&transaction.signature).into_string();
-                                let slot_landed = tx_update.slot;
-                                let confirmed = transaction
-                                    .meta
-                                    .as_ref()
-                                    .is_some_and(|meta| meta.err.is_none());
+                if let Some(UpdateOneof::Transaction(tx_update)) = msg.update_oneof {
+                    if let Some(transaction) = tx_update.transaction {
+                        let tx_signature = bs58::encode(&transaction.signature).into_string();
+                        let slot_landed = tx_update.slot;
+                        let confirmed = transaction
+                            .meta
+                            .as_ref()
+                            .is_some_and(|meta| meta.err.is_none());
 
-                                info!(
-                                        "[Transaction Watcher] Transaction update - Signature: {:?}, Slot: {:?}, Confirmed: {:?}",
-                                        tx_signature, slot_landed, confirmed
-                                    );
+                        info!(
+                            "[Transaction Watcher] Transaction update - Signature: {:?}, Slot: {:?}, Confirmed: {:?}",
+                            tx_signature, slot_landed, confirmed
+                        );
 
-                                let transaction_signature_for_channel_send =
-                                    tx_signature.clone();
-                                if let Err(e) = tx_updates_tx
-                                    .send((transaction_signature_for_channel_send, slot_landed, confirmed))
-                                    .await
-                                {
-                                    error!(
-                                            "[Transaction Watcher] Failed to send transaction update for signature {:?}, slot {:?}, confirmed {:?}: {:?}",
-                                            tx_signature, slot_landed, confirmed, e
-                                        );
-                                }
-                            }
-                        }
-                        _ => {
-                            // Ignore other update types
+                        let transaction_signature_for_channel_send = tx_signature.clone();
+                        if let Err(e) = tx_updates_tx
+                            .send((
+                                transaction_signature_for_channel_send,
+                                slot_landed,
+                                confirmed,
+                            ))
+                            .await
+                        {
+                            error!(
+                                "[Transaction Watcher] Failed to send transaction update for signature {:?}, slot {:?}, confirmed {:?}: {:?}",
+                                tx_signature, slot_landed, confirmed, e
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- restore a shared Prometheus registry so /metrics serves the same registry instance that the app updates
- add a regression test that verifies the exported registry contains the ping thing latency metrics
- fix existing clippy collapsible-match issues and apply rustfmt so cargo clippy --all-targets -- -D warnings passes

## Context
Recent allocs were exposing /metrics, but many ping thing series were missing from Grafana because the handler was scraping a cloned registry instead of the shared live registry.

This restores the shared-registry behavior that the earlier empty-metrics fix depended on, which should bring back series such as ping_thing_client_confirmation_latency_bucket and ping_thing_client_slot_latency_bucket in new allocs.