### PR TITLE
fix: append /sendtx to endpoint when kind is triton_sendtx

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,13 @@ fn configured_send_transaction_endpoint_from_environment(
         })
         .unwrap_or_default();
 
+    let endpoint = match kind {
+        SendTransactionEndpointKind::TritonSendTx if !endpoint.ends_with("/sendtx") => {
+            format!("{}/sendtx", endpoint.trim_end_matches('/'))
+        }
+        _ => endpoint,
+    };
+
     Ok(Some(ConfiguredSendTransactionEndpoint {
         endpoint,
         kind,


### PR DESCRIPTION
## Summary

When \`SEND_TX_KIND=triton_sendtx\` and \`SEND_TX_ENDPOINT\` is a bare base URL (e.g. \`https://host.example.com/<token>\`), the client was POSTing to that URL directly, which returns 415 since the base endpoint only accepts \`application/json\`.

This fix automatically appends \`/sendtx\` to \`SEND_TX_ENDPOINT\` during configuration parsing if the kind is \`triton_sendtx\` and the path doesn't already end with \`/sendtx\`.

## Test plan

- [ ] \`SEND_TX_ENDPOINT=https://host/<token>\` + \`SEND_TX_KIND=triton_sendtx\` → sends to \`https://host/<token>/sendtx\`
- [ ] \`SEND_TX_ENDPOINT=https://host/<token>/sendtx\` + \`SEND_TX_KIND=triton_sendtx\` → no double suffix
- [ ] \`SEND_TX_KIND=json_rpc\` → endpoint unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)