### PR TITLE
refactor: fix errors, metricsd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -447,7 +447,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -461,15 +461,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "autotools"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "axum"
@@ -491,7 +482,7 @@ dependencies = [
  "pin-project-lite",
  "serde_core",
  "sync_wrapper",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -614,7 +605,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -680,7 +671,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -744,7 +735,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -993,7 +984,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1002,8 +993,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1017,7 +1018,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1026,9 +1040,20 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1129,7 +1154,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1152,7 +1177,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1275,7 +1300,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1525,7 +1550,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2142,7 +2167,7 @@ checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2536,7 +2561,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2609,7 +2634,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2662,7 +2687,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2717,6 +2742,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pbkdf2"
@@ -2778,7 +2809,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2795,7 +2826,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ping-thing-client-rust"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2908,7 +2939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2922,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2941,7 +2972,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2972,7 +3003,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -2986,7 +3017,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3010,15 +3041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf-src"
-version = "1.1.0+21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
-dependencies = [
- "autotools",
-]
-
-[[package]]
 name = "protobuf-support"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3048,70 @@ checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "pulldown-cmark"
@@ -3064,7 +3150,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3096,7 +3182,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.35",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3119,7 +3205,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3141,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3359,7 +3445,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -3701,7 +3787,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3745,10 +3831,10 @@ version = "3.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3785,6 +3871,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
@@ -3912,7 +4004,7 @@ dependencies = [
  "spl-token-group-interface",
  "spl-token-interface",
  "spl-token-metadata-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zstd",
 ]
 
@@ -3951,14 +4043,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.0.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37320fd2945c5d654b2c6210624a52d66c3f1f73b653ed211ab91a703b35bdd"
+checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -3966,14 +4058,16 @@ dependencies = [
  "curve25519-dalek",
  "five8 1.0.0",
  "five8_const",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "serde_derive",
+ "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
+ "wincode",
 ]
 
 [[package]]
@@ -4048,7 +4142,7 @@ dependencies = [
  "ark-serialize",
  "bytemuck",
  "solana-define-syscall 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4150,7 +4244,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-udp-client",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -4235,7 +4329,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm-transaction",
  "solana-transaction-error",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4294,7 +4388,7 @@ dependencies = [
  "solana-metrics",
  "solana-time-utils",
  "solana-transaction-error",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -4308,7 +4402,7 @@ dependencies = [
  "solana-define-syscall 4.0.1",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
  "solana-stable-layout",
 ]
 
@@ -4323,7 +4417,7 @@ dependencies = [
  "curve25519-dalek",
  "solana-define-syscall 3.0.0",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4337,6 +4431,12 @@ name = "solana-define-syscall"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
+
+[[package]]
+name = "solana-define-syscall"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
 
 [[package]]
 name = "solana-derivation-path"
@@ -4425,7 +4525,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-system-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4542,7 +4642,7 @@ dependencies = [
  "serde_derive",
  "solana-define-syscall 4.0.1",
  "solana-instruction-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -4596,7 +4696,7 @@ dependencies = [
  "ed25519-dalek-bip32",
  "five8 1.0.0",
  "rand 0.8.5",
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
  "solana-derivation-path",
  "solana-seed-derivable",
  "solana-seed-phrase",
@@ -4725,7 +4825,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-sha256-hasher",
  "solana-time-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4867,7 +4967,7 @@ dependencies = [
  "ark-bn254",
  "light-poseidon",
  "solana-define-syscall 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4946,7 +5046,7 @@ dependencies = [
  "solana-account-info",
  "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -5037,11 +5137,11 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f7104d456b58e1418c21a8581e89810278d1190f70f27ece7fc0b2c9282a57"
+checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
@@ -5063,7 +5163,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rpc-client-types",
  "solana-signature",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -5097,7 +5197,7 @@ dependencies = [
  "solana-streamer",
  "solana-tls-utils",
  "solana-transaction-error",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -5202,7 +5302,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5219,7 +5319,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rpc-client",
  "solana-sdk-ids",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5245,7 +5345,7 @@ dependencies = [
  "solana-transaction-status-client-types",
  "solana-version",
  "spl-generic-token",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5267,7 +5367,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustc-demangle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "winapi",
 ]
 
@@ -5306,7 +5406,7 @@ dependencies = [
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-error",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5327,7 +5427,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5338,7 +5438,7 @@ checksum = "9de18cfdab99eeb940fbedd8c981fa130c0d76252da75d05446f22fae8b51932"
 dependencies = [
  "k256",
  "solana-define-syscall 4.0.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5574,7 +5674,7 @@ dependencies = [
  "solana-tls-utils",
  "solana-transaction-error",
  "solana-transaction-metrics-tracker",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "x509-parser",
@@ -5782,7 +5882,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction",
  "solana-transaction-error",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -5795,7 +5895,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
  "solana-hash 4.0.1",
  "solana-instruction",
  "solana-instruction-error",
@@ -5895,7 +5995,7 @@ dependencies = [
  "spl-token-group-interface",
  "spl-token-interface",
  "spl-token-metadata-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5920,7 +6020,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5935,7 +6035,7 @@ dependencies = [
  "solana-net-utils",
  "solana-streamer",
  "solana-transaction-error",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -6010,7 +6110,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6045,7 +6145,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -6100,7 +6200,7 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6112,7 +6212,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.104",
+ "syn 2.0.118",
  "thiserror 1.0.69",
 ]
 
@@ -6152,7 +6252,7 @@ dependencies = [
  "solana-program-option",
  "solana-pubkey 3.0.0",
  "solana-zk-sdk",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6180,7 +6280,7 @@ dependencies = [
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "spl-type-length-value",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6200,7 +6300,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-zk-sdk",
  "spl-pod",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6211,7 +6311,7 @@ checksum = "a0cd59fce3dc00f563c6fa364d67c3f200d278eae681f4dc250240afcfe044b1"
 dependencies = [
  "curve25519-dalek",
  "solana-zk-sdk",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6229,7 +6329,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "spl-discriminator",
  "spl-pod",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6249,7 +6349,7 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6268,7 +6368,7 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-type-length-value",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6286,7 +6386,7 @@ dependencies = [
  "solana-program-error",
  "spl-discriminator",
  "spl-pod",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6320,9 +6420,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6358,7 +6458,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6406,11 +6506,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -6421,18 +6521,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6516,7 +6616,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6632,7 +6732,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6648,7 +6748,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6686,9 +6786,24 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6723,7 +6838,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -6760,7 +6875,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7008,7 +7123,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -7043,7 +7158,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7142,6 +7257,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "wincode"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror 2.0.18",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7162,7 +7302,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7173,7 +7313,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7492,42 +7632,39 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "10.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79834bb0660b17e27c32c84778d661fb406f9fe382670ea628f01062b26ae1a"
+checksum = "665537dc14c6f2d379f61de21a66052603ebe71f27f4df5fa5250992e08bde38"
 dependencies = [
+ "arc-swap",
  "bytes",
  "futures",
- "thiserror 2.0.17",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tokio",
  "tonic",
  "tonic-health",
+ "tower 0.4.13",
  "yellowstone-grpc-proto",
 ]
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "10.1.1"
+version = "12.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b515077c7db0e9e0dcc506bc6e7bbd6906fcdc3d4978d7039a23a415af4390b"
+checksum = "c91071690a2b0a078a4712ecca7be37aa929b474a74f4f269c61582f8e2a6139"
 dependencies = [
  "anyhow",
- "bincode",
  "prost",
  "prost-types",
- "protobuf-src",
- "solana-account",
- "solana-account-decoder",
- "solana-clock",
- "solana-hash 3.1.0",
- "solana-message",
- "solana-pubkey 3.0.0",
- "solana-signature",
- "solana-transaction",
- "solana-transaction-context",
- "solana-transaction-error",
- "solana-transaction-status",
+ "protoc-bin-vendored",
+ "siphasher 1.0.1",
+ "solana-pubkey 4.2.0",
+ "thiserror 2.0.18",
  "tonic",
- "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
 ]
@@ -7552,7 +7689,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -7573,7 +7710,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7593,7 +7730,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -7614,7 +7751,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7647,7 +7784,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ping-thing-client-rust"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]
@@ -41,5 +41,5 @@ tonic = "0.14.2"
 prost = "0.14.1"
 prost-types = "0.14.1"
 futures = "0.3.31"
-yellowstone-grpc-client = "10.1.1"
-yellowstone-grpc-proto = "10.1.1"
+yellowstone-grpc-client = "13.2.0"
+yellowstone-grpc-proto = "12.5.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"

--- a/src/main.rs
+++ b/src/main.rs
@@ -628,33 +628,41 @@ async fn send_validators_app_payload(
     client: &Client,
     va_api_key: &str,
     payload: &Value,
+    request_timeout: tokio::time::Duration,
 ) -> Result<()> {
     const MAX_ATTEMPTS: u8 = 3;
     let mut last_error = String::new();
 
     for attempt in 1..=MAX_ATTEMPTS {
-        match client
-            .post("https://www.validators.app/api/v1/ping-thing/mainnet")
-            .header("Content-Type", "application/json")
-            .header("Token", va_api_key)
-            .json(payload)
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status().is_success() {
-                    return Ok(());
-                }
+        let request = async {
+            let response = client
+                .post("https://www.validators.app/api/v1/ping-thing/mainnet")
+                .header("Content-Type", "application/json")
+                .header("Token", va_api_key)
+                .json(payload)
+                .send()
+                .await?;
 
-                let status = response.status();
-                let response_body = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|error| format!("failed to read response body: {error:?}"));
-                last_error = format!("status {status}: {response_body}");
+            if response.status().is_success() {
+                return Ok(());
             }
-            Err(error) => {
+
+            let status = response.status();
+            let response_body = response
+                .text()
+                .await
+                .unwrap_or_else(|error| format!("failed to read response body: {error:?}"));
+
+            Err(anyhow::anyhow!("status {status}: {response_body}"))
+        };
+
+        match tokio::time::timeout(request_timeout, request).await {
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(error)) => {
                 last_error = error.to_string();
+            }
+            Err(_) => {
+                last_error = format!("request timed out after {:?}", request_timeout);
             }
         }
 
@@ -666,6 +674,32 @@ async fn send_validators_app_payload(
     Err(anyhow::anyhow!(
         "failed after {MAX_ATTEMPTS} attempts: {last_error}"
     ))
+}
+
+fn set_watcher_up(metrics: Option<&Arc<Metrics>>, pinger_name: &str, watcher: &str, is_up: bool) {
+    if let Some(metrics) = metrics {
+        metrics
+            .watcher_up
+            .with_label_values(&[pinger_name, watcher])
+            .set(i64::from(is_up));
+    }
+}
+
+fn record_watcher_fatal_error(metrics: Option<&Arc<Metrics>>, pinger_name: &str, watcher: &str) {
+    if let Some(metrics) = metrics {
+        metrics
+            .watcher_fatal_errors
+            .with_label_values(&[pinger_name, watcher])
+            .inc();
+    }
+}
+
+fn validators_app_request_timeout_from_environment() -> tokio::time::Duration {
+    let timeout_ms = std::env::var("VALIDATORS_APP_REQUEST_TIMEOUT_MS")
+        .unwrap_or_else(|_| "5000".to_string())
+        .parse::<u64>()
+        .unwrap_or(5000);
+    tokio::time::Duration::from_millis(timeout_ms)
 }
 
 #[tokio::main]
@@ -772,6 +806,12 @@ async fn main() -> Result<()> {
         .unwrap_or(false);
     info!("SKIP_VALIDATORS_APP: {:?}", skip_validators_app);
 
+    let validators_app_request_timeout = validators_app_request_timeout_from_environment();
+    info!(
+        "VALIDATORS_APP_REQUEST_TIMEOUT_MS: {:?}",
+        validators_app_request_timeout.as_millis()
+    );
+
     let skip_prometheus = std::env::var("SKIP_PROMETHEUS")
         .map(|v| v == "true")
         .unwrap_or(false);
@@ -871,24 +911,25 @@ async fn main() -> Result<()> {
     let blockhash_metrics = metrics.clone();
     let blockhash_pinger_name = pinger_name.clone();
     tokio::spawn(async move {
-        if let Some(metrics) = &blockhash_metrics {
-            metrics
-                .watcher_up
-                .with_label_values(&[&blockhash_pinger_name, "blockhash"])
-                .set(1);
-        }
-        if let Err(e) = watch_blockhash(grpc_client_blockhash, g_blockhash_clone, commitment).await
-        {
-            if let Some(metrics) = &blockhash_metrics {
-                metrics
-                    .watcher_up
-                    .with_label_values(&[&blockhash_pinger_name, "blockhash"])
-                    .set(0);
-                metrics
-                    .watcher_fatal_errors
-                    .with_label_values(&[&blockhash_pinger_name, "blockhash"])
-                    .inc();
-            }
+        set_watcher_up(
+            blockhash_metrics.as_ref(),
+            &blockhash_pinger_name,
+            "blockhash",
+            true,
+        );
+        let result = watch_blockhash(grpc_client_blockhash, g_blockhash_clone, commitment).await;
+        set_watcher_up(
+            blockhash_metrics.as_ref(),
+            &blockhash_pinger_name,
+            "blockhash",
+            false,
+        );
+        if let Err(e) = result {
+            record_watcher_fatal_error(
+                blockhash_metrics.as_ref(),
+                &blockhash_pinger_name,
+                "blockhash",
+            );
             error!(
                 "[Blockhash Watcher] Task failed for commitment {:?}: {:?}",
                 commitment, e
@@ -903,23 +944,11 @@ async fn main() -> Result<()> {
     let slot_metrics = metrics.clone();
     let slot_pinger_name = pinger_name.clone();
     tokio::spawn(async move {
-        if let Some(metrics) = &slot_metrics {
-            metrics
-                .watcher_up
-                .with_label_values(&[&slot_pinger_name, "slot"])
-                .set(1);
-        }
-        if let Err(e) = watch_slot(grpc_client_slot, g_slot_sent_clone, commitment).await {
-            if let Some(metrics) = &slot_metrics {
-                metrics
-                    .watcher_up
-                    .with_label_values(&[&slot_pinger_name, "slot"])
-                    .set(0);
-                metrics
-                    .watcher_fatal_errors
-                    .with_label_values(&[&slot_pinger_name, "slot"])
-                    .inc();
-            }
+        set_watcher_up(slot_metrics.as_ref(), &slot_pinger_name, "slot", true);
+        let result = watch_slot(grpc_client_slot, g_slot_sent_clone, commitment).await;
+        set_watcher_up(slot_metrics.as_ref(), &slot_pinger_name, "slot", false);
+        if let Err(e) = result {
+            record_watcher_fatal_error(slot_metrics.as_ref(), &slot_pinger_name, "slot");
             error!(
                 "[Slot Watcher] Task failed for commitment {:?}: {:?}",
                 commitment, e
@@ -957,30 +986,31 @@ async fn main() -> Result<()> {
     let transaction_metrics = metrics.clone();
     let transaction_pinger_name = pinger_name.clone();
     tokio::spawn(async move {
-        if let Some(metrics) = &transaction_metrics {
-            metrics
-                .watcher_up
-                .with_label_values(&[&transaction_pinger_name, "transaction"])
-                .set(1);
-        }
-        if let Err(e) = watch_transactions(
+        set_watcher_up(
+            transaction_metrics.as_ref(),
+            &transaction_pinger_name,
+            "transaction",
+            true,
+        );
+        let result = watch_transactions(
             grpc_client_transactions,
             tx_updates_tx,
             wallet_pubkey,
             commitment,
         )
-        .await
-        {
-            if let Some(metrics) = &transaction_metrics {
-                metrics
-                    .watcher_up
-                    .with_label_values(&[&transaction_pinger_name, "transaction"])
-                    .set(0);
-                metrics
-                    .watcher_fatal_errors
-                    .with_label_values(&[&transaction_pinger_name, "transaction"])
-                    .inc();
-            }
+        .await;
+        set_watcher_up(
+            transaction_metrics.as_ref(),
+            &transaction_pinger_name,
+            "transaction",
+            false,
+        );
+        if let Err(e) = result {
+            record_watcher_fatal_error(
+                transaction_metrics.as_ref(),
+                &transaction_pinger_name,
+                "transaction",
+            );
             error!(
                 "[Transaction Watcher] Task failed for wallet {:?}: {:?}",
                 wallet_pubkey, e
@@ -1340,6 +1370,7 @@ async fn main() -> Result<()> {
                         &validators_app_http_client,
                         &va_api_key,
                         &payload,
+                        validators_app_request_timeout,
                     )
                     .await
                     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -624,6 +624,50 @@ fn validate_response_signature(
     Ok(())
 }
 
+async fn send_validators_app_payload(
+    client: &Client,
+    va_api_key: &str,
+    payload: &Value,
+) -> Result<()> {
+    const MAX_ATTEMPTS: u8 = 3;
+    let mut last_error = String::new();
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        match client
+            .post("https://www.validators.app/api/v1/ping-thing/mainnet")
+            .header("Content-Type", "application/json")
+            .header("Token", va_api_key)
+            .json(payload)
+            .send()
+            .await
+        {
+            Ok(response) => {
+                if response.status().is_success() {
+                    return Ok(());
+                }
+
+                let status = response.status();
+                let response_body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|error| format!("failed to read response body: {error:?}"));
+                last_error = format!("status {status}: {response_body}");
+            }
+            Err(error) => {
+                last_error = error.to_string();
+            }
+        }
+
+        if attempt < MAX_ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_millis(200 * u64::from(attempt))).await;
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "failed after {MAX_ATTEMPTS} attempts: {last_error}"
+    ))
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     info!("=== Starting Ping Thing Client ===");
@@ -761,6 +805,7 @@ async fn main() -> Result<()> {
 
     let rpc_client = Arc::new(RpcClient::new(rpc_endpoint.clone()));
     let send_transaction_http_client = Client::new();
+    let validators_app_http_client = Client::new();
 
     let g_blockhash = Arc::new(Mutex::new(GlobalBlockhash::new()));
     let g_slot_sent = Arc::new(Mutex::new(GlobalSlotSent::new()));
@@ -823,9 +868,27 @@ async fn main() -> Result<()> {
     // Spawn blockhash watching task
     let g_blockhash_clone = Arc::clone(&g_blockhash);
     let grpc_client_blockhash = Arc::clone(&shared_grpc_client);
+    let blockhash_metrics = metrics.clone();
+    let blockhash_pinger_name = pinger_name.clone();
     tokio::spawn(async move {
+        if let Some(metrics) = &blockhash_metrics {
+            metrics
+                .watcher_up
+                .with_label_values(&[&blockhash_pinger_name, "blockhash"])
+                .set(1);
+        }
         if let Err(e) = watch_blockhash(grpc_client_blockhash, g_blockhash_clone, commitment).await
         {
+            if let Some(metrics) = &blockhash_metrics {
+                metrics
+                    .watcher_up
+                    .with_label_values(&[&blockhash_pinger_name, "blockhash"])
+                    .set(0);
+                metrics
+                    .watcher_fatal_errors
+                    .with_label_values(&[&blockhash_pinger_name, "blockhash"])
+                    .inc();
+            }
             error!(
                 "[Blockhash Watcher] Task failed for commitment {:?}: {:?}",
                 commitment, e
@@ -837,8 +900,26 @@ async fn main() -> Result<()> {
     // Spawn slot watching task
     let g_slot_sent_clone = Arc::clone(&g_slot_sent);
     let grpc_client_slot = Arc::clone(&shared_grpc_client);
+    let slot_metrics = metrics.clone();
+    let slot_pinger_name = pinger_name.clone();
     tokio::spawn(async move {
+        if let Some(metrics) = &slot_metrics {
+            metrics
+                .watcher_up
+                .with_label_values(&[&slot_pinger_name, "slot"])
+                .set(1);
+        }
         if let Err(e) = watch_slot(grpc_client_slot, g_slot_sent_clone, commitment).await {
+            if let Some(metrics) = &slot_metrics {
+                metrics
+                    .watcher_up
+                    .with_label_values(&[&slot_pinger_name, "slot"])
+                    .set(0);
+                metrics
+                    .watcher_fatal_errors
+                    .with_label_values(&[&slot_pinger_name, "slot"])
+                    .inc();
+            }
             error!(
                 "[Slot Watcher] Task failed for commitment {:?}: {:?}",
                 commitment, e
@@ -873,7 +954,15 @@ async fn main() -> Result<()> {
 
     // Spawn transaction watching task for the wallet
     let grpc_client_transactions = Arc::clone(&shared_grpc_client);
+    let transaction_metrics = metrics.clone();
+    let transaction_pinger_name = pinger_name.clone();
     tokio::spawn(async move {
+        if let Some(metrics) = &transaction_metrics {
+            metrics
+                .watcher_up
+                .with_label_values(&[&transaction_pinger_name, "transaction"])
+                .set(1);
+        }
         if let Err(e) = watch_transactions(
             grpc_client_transactions,
             tx_updates_tx,
@@ -882,6 +971,16 @@ async fn main() -> Result<()> {
         )
         .await
         {
+            if let Some(metrics) = &transaction_metrics {
+                metrics
+                    .watcher_up
+                    .with_label_values(&[&transaction_pinger_name, "transaction"])
+                    .set(0);
+                metrics
+                    .watcher_fatal_errors
+                    .with_label_values(&[&transaction_pinger_name, "transaction"])
+                    .inc();
+            }
             error!(
                 "[Transaction Watcher] Task failed for wallet {:?}: {:?}",
                 wallet_pubkey, e
@@ -1064,9 +1163,11 @@ async fn main() -> Result<()> {
         }
         info!("[TX] Stored transaction in sent_transactions map");
 
-        // Start 20-second resend loop with confirmation handling
-        info!("[TX] Starting resend loop (20 second timeout)...");
-        let timeout_duration = tokio::time::Duration::from_secs(20);
+        info!(
+            "[TX] Starting resend loop ({:?} second timeout)...",
+            tx_confirmation_timeout
+        );
+        let timeout_duration = tokio::time::Duration::from_secs(tx_confirmation_timeout);
         let resend_interval_duration = tokio::time::Duration::from_millis(2000);
 
         let mut confirmed = false;
@@ -1079,9 +1180,15 @@ async fn main() -> Result<()> {
             // Check if timeout elapsed
             if start_time.elapsed() >= timeout_duration {
                 warn!(
-                    "[TX] Transaction {:?} timed out after 20 seconds",
-                    signature
+                    "[TX] Transaction {:?} timed out after {:?} seconds",
+                    signature, tx_confirmation_timeout
                 );
+                if let Some(ref metrics) = metrics {
+                    metrics
+                        .transaction_timeouts
+                        .with_label_values(&[&pinger_name])
+                        .inc();
+                }
                 break;
             }
 
@@ -1108,12 +1215,19 @@ async fn main() -> Result<()> {
                     }
                 }
                 Ok(None) => {
-                    // Channel closed
+                    if let Some(ref metrics) = metrics {
+                        metrics
+                            .confirmation_channel_closed
+                            .with_label_values(&[&pinger_name])
+                            .inc();
+                    }
                     error!(
                         "[TX] Transaction update channel closed unexpectedly for signature: {:?}",
                         signature
                     );
-                    break;
+                    return Err(anyhow::anyhow!(
+                        "transaction update channel closed while waiting for signature {signature}"
+                    ));
                 }
                 Err(_) => {
                     // Timeout elapsed (2 seconds passed), resend transaction
@@ -1222,26 +1336,23 @@ async fn main() -> Result<()> {
                 if !skip_validators_app {
                     info!("[TX] Sending metrics to Validators.app...");
 
-                    let client = Client::new();
-                    match client
-                        .post("https://www.validators.app/api/v1/ping-thing/mainnet")
-                        .header("Content-Type", "application/json")
-                        .header("Token", &va_api_key)
-                        .json(&payload)
-                        .send()
-                        .await
+                    match send_validators_app_payload(
+                        &validators_app_http_client,
+                        &va_api_key,
+                        &payload,
+                    )
+                    .await
                     {
-                        Ok(response) => {
-                            if response.status().is_success() {
-                                info!("[TX] Successfully sent metrics to Validators.app");
-                            } else {
-                                error!(
-                                    "[TX] Failed to send to Validators.app for signature {:?} - Status: {:?}",
-                                    signature, response.status()
-                                );
-                            }
+                        Ok(()) => {
+                            info!("[TX] Successfully sent metrics to Validators.app");
                         }
                         Err(e) => {
+                            if let Some(ref metrics) = metrics {
+                                metrics
+                                    .validators_app_send_failures
+                                    .with_label_values(&[&pinger_name])
+                                    .inc();
+                            }
                             error!(
                                 "[TX] Error sending to Validators.app for signature {:?}: {:?}",
                                 signature, e
@@ -1264,8 +1375,8 @@ async fn main() -> Result<()> {
             }
         } else {
             warn!(
-                "[TX] Transaction {:?} not confirmed or failed after 20 seconds",
-                signature
+                "[TX] Transaction {:?} not confirmed or failed after {:?} seconds",
+                signature, tx_confirmation_timeout
             );
         }
 

--- a/src/utils/blockhash.rs
+++ b/src/utils/blockhash.rs
@@ -1,11 +1,10 @@
 use anyhow::{Context, Result};
 use futures::StreamExt;
-use log::{error, warn};
+use log::error;
 use solana_sdk::hash::Hash;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tokio::time::{sleep, Duration};
 use yellowstone_grpc_client::GeyserGrpcClient;
 use yellowstone_grpc_proto::prelude::{
     subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
@@ -31,94 +30,92 @@ impl GlobalBlockhash {
 
 /// Watches blockhash updates via gRPC block_meta subscription
 pub async fn watch_blockhash(
-    grpc_client: Arc<Mutex<GeyserGrpcClient<impl yellowstone_grpc_client::Interceptor + 'static>>>,
+    grpc_client: Arc<Mutex<GeyserGrpcClient>>,
     g_blockhash: Arc<Mutex<GlobalBlockhash>>,
     commitment: CommitmentLevel,
 ) -> Result<()> {
-    loop {
-        // Create subscription request for block_meta
-        let mut blocks_filter = HashMap::new();
-        blocks_filter.insert(
-            "block_meta".to_string(),
-            SubscribeRequestFilterBlocksMeta {},
-        );
+    // Create subscription request for block_meta
+    let mut blocks_filter = HashMap::new();
+    blocks_filter.insert(
+        "block_meta".to_string(),
+        SubscribeRequestFilterBlocksMeta {},
+    );
 
-        let subscribe_request = SubscribeRequest {
-            blocks_meta: blocks_filter,
-            commitment: Some(commitment.into()),
-            ..Default::default()
-        };
+    let subscribe_request = SubscribeRequest {
+        blocks_meta: blocks_filter,
+        commitment: Some(commitment.into()),
+        ..Default::default()
+    };
 
-        let (_subscribe_tx, mut stream) = {
-            let mut client = grpc_client.lock().await;
-            client
-                .subscribe_with_request(Some(subscribe_request))
-                .await
-                .context("Failed to create block_meta subscription")?
-        };
+    let mut stream = {
+        let mut client = grpc_client.lock().await;
+        client
+            .subscribe_once(subscribe_request)
+            .await
+            .context("Failed to create block_meta subscription")?
+    };
 
-        // Process stream updates
-        while let Some(message) = stream.next().await {
-            match message {
-                Ok(msg) => {
-                    if let Some(UpdateOneof::BlockMeta(block_meta_update)) = msg.update_oneof {
-                        let blockhash_str = block_meta_update.blockhash;
-                        let block_height = block_meta_update
-                            .block_height
-                            .map(|bh| bh.block_height)
-                            .unwrap_or(0);
+    // Process stream updates
+    while let Some(message) = stream.next().await {
+        match message {
+            Ok(msg) => {
+                if let Some(UpdateOneof::BlockMeta(block_meta_update)) = msg.update_oneof {
+                    let blockhash_str = block_meta_update.blockhash;
+                    let block_height = block_meta_update
+                        .block_height
+                        .map(|bh| bh.block_height)
+                        .unwrap_or(0);
 
-                        // Parse blockhash from base58 string
-                        let hash_bytes = match bs58::decode(&blockhash_str).into_vec() {
-                            Ok(decoded) => {
-                                if decoded.len() == 32 {
-                                    match <[u8; 32]>::try_from(decoded.as_slice()) {
-                                        Ok(arr) => arr,
-                                        Err(_) => {
-                                            error!(
-                                                "[Blockhash Watcher] Failed to convert decoded blockhash to array for blockhash {:?} with length {:?}",
-                                                blockhash_str, decoded.len()
-                                            );
-                                            continue;
-                                        }
+                    // Parse blockhash from base58 string
+                    let hash_bytes = match bs58::decode(&blockhash_str).into_vec() {
+                        Ok(decoded) => {
+                            if decoded.len() == 32 {
+                                match <[u8; 32]>::try_from(decoded.as_slice()) {
+                                    Ok(arr) => arr,
+                                    Err(_) => {
+                                        error!(
+                                            "[Blockhash Watcher] Failed to convert decoded blockhash to array for blockhash {:?} with length {:?}",
+                                            blockhash_str, decoded.len()
+                                        );
+                                        continue;
                                     }
-                                } else {
-                                    error!(
-                                        "[Blockhash Watcher] Decoded blockhash has wrong length: {:?} (expected 32)",
-                                        decoded.len()
-                                    );
-                                    continue;
                                 }
-                            }
-                            Err(e) => {
-                                error!("[Blockhash Watcher] Failed to decode blockhash: {:?}", e);
+                            } else {
+                                error!(
+                                    "[Blockhash Watcher] Decoded blockhash has wrong length: {:?} (expected 32)",
+                                    decoded.len()
+                                );
                                 continue;
                             }
-                        };
-
-                        let new_hash = Hash::new_from_array(hash_bytes);
-
-                        // Update global blockhash if different
-                        let mut g = g_blockhash.lock().await;
-                        let previous_hash = g.value;
-
-                        if previous_hash != Some(new_hash) {
-                            g.value = Some(new_hash);
-                            g.last_valid_block_height = block_height;
-                            g.updated_at = chrono::Utc::now().timestamp();
-                            drop(g);
                         }
+                        Err(e) => {
+                            error!("[Blockhash Watcher] Failed to decode blockhash: {:?}", e);
+                            continue;
+                        }
+                    };
+
+                    let new_hash = Hash::new_from_array(hash_bytes);
+
+                    // Update global blockhash if different
+                    let mut g = g_blockhash.lock().await;
+                    let previous_hash = g.value;
+
+                    if previous_hash != Some(new_hash) {
+                        g.value = Some(new_hash);
+                        g.last_valid_block_height = block_height;
+                        g.updated_at = chrono::Utc::now().timestamp();
+                        drop(g);
                     }
                 }
-                Err(e) => {
-                    error!("[Blockhash Watcher] Stream error: {:?}", e);
-                    break;
-                }
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "[Blockhash Watcher] Fatal stream error: {:?}",
+                    e
+                ));
             }
         }
-
-        // Stream ended, reconnect with exponential backoff
-        warn!("[Blockhash Watcher] Stream disconnected, reconnecting in 5 seconds...");
-        sleep(Duration::from_secs(5)).await;
     }
+
+    Err(anyhow::anyhow!("[Blockhash Watcher] Stream ended"))
 }

--- a/src/utils/grpc_client.rs
+++ b/src/utils/grpc_client.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use log::{debug, info, warn};
 use tonic::transport::ClientTlsConfig;
-use yellowstone_grpc_client::{GeyserGrpcClient, Interceptor};
+use yellowstone_grpc_client::{GeyserGrpcClient, ReconnectConfig};
 use yellowstone_grpc_proto::prelude::CommitmentLevel;
 
 /// Creates a gRPC client with proper configuration
@@ -9,7 +9,7 @@ use yellowstone_grpc_proto::prelude::CommitmentLevel;
 pub async fn create_grpc_client(
     endpoint: &str,
     x_token: Option<String>,
-) -> Result<GeyserGrpcClient<impl Interceptor>> {
+) -> Result<GeyserGrpcClient> {
     info!("[gRPC Client] Creating client for endpoint: {:?}", endpoint);
 
     // Always use TLS config with native roots (works for both http and https)
@@ -22,7 +22,8 @@ pub async fn create_grpc_client(
     let builder = GeyserGrpcClient::build_from_shared(endpoint.to_string())
         .context("Failed to build gRPC client")?
         .tls_config(tls_config)
-        .context("Failed to configure TLS")?;
+        .context("Failed to configure TLS")?
+        .set_reconnect_config(ReconnectConfig::default());
     debug!("[gRPC Client] Client builder created with TLS config");
 
     // Add x-token header if provided

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use log::{debug, info};
-use prometheus::{Encoder, HistogramOpts, HistogramVec, Registry};
+use prometheus::{
+    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry,
+};
 use std::sync::Arc;
 use warp::Filter;
 
@@ -8,6 +10,11 @@ pub struct Metrics {
     pub registry: Arc<Registry>,
     pub confirmation_latency: HistogramVec,
     pub slot_latency: HistogramVec,
+    pub watcher_up: IntGaugeVec,
+    pub watcher_fatal_errors: IntCounterVec,
+    pub confirmation_channel_closed: IntCounterVec,
+    pub transaction_timeouts: IntCounterVec,
+    pub validators_app_send_failures: IntCounterVec,
 }
 
 impl Metrics {
@@ -59,15 +66,65 @@ impl Metrics {
             &["pinger_name"],
         )?;
 
+        let watcher_up = IntGaugeVec::new(
+            Opts::new(
+                "ping_thing_client_watcher_up",
+                "Whether a watcher task is running",
+            ),
+            &["pinger_name", "watcher"],
+        )?;
+
+        let watcher_fatal_errors = IntCounterVec::new(
+            Opts::new(
+                "ping_thing_client_watcher_fatal_errors_total",
+                "Fatal watcher task errors",
+            ),
+            &["pinger_name", "watcher"],
+        )?;
+
+        let confirmation_channel_closed = IntCounterVec::new(
+            Opts::new(
+                "ping_thing_client_confirmation_channel_closed_total",
+                "Times the transaction update channel closed",
+            ),
+            &["pinger_name"],
+        )?;
+
+        let transaction_timeouts = IntCounterVec::new(
+            Opts::new(
+                "ping_thing_client_transaction_timeouts_total",
+                "Transactions that were not confirmed before the local timeout",
+            ),
+            &["pinger_name"],
+        )?;
+
+        let validators_app_send_failures = IntCounterVec::new(
+            Opts::new(
+                "ping_thing_client_validators_app_send_failures_total",
+                "Validators.app API send failures",
+            ),
+            &["pinger_name"],
+        )?;
+
         info!("[Metrics] Registering metrics with Prometheus registry...");
         registry.register(Box::new(confirmation_latency.clone()))?;
         registry.register(Box::new(slot_latency.clone()))?;
+        registry.register(Box::new(watcher_up.clone()))?;
+        registry.register(Box::new(watcher_fatal_errors.clone()))?;
+        registry.register(Box::new(confirmation_channel_closed.clone()))?;
+        registry.register(Box::new(transaction_timeouts.clone()))?;
+        registry.register(Box::new(validators_app_send_failures.clone()))?;
         info!("[Metrics] All metrics registered successfully");
 
         Ok(Self {
             registry,
             confirmation_latency,
             slot_latency,
+            watcher_up,
+            watcher_fatal_errors,
+            confirmation_channel_closed,
+            transaction_timeouts,
+            validators_app_send_failures,
         })
     }
 
@@ -113,6 +170,26 @@ mod tests {
             .slot_latency
             .with_label_values(&["test-pinger"])
             .observe(1.0);
+        metrics
+            .watcher_up
+            .with_label_values(&["test-pinger", "transaction"])
+            .set(1);
+        metrics
+            .watcher_fatal_errors
+            .with_label_values(&["test-pinger", "transaction"])
+            .inc();
+        metrics
+            .confirmation_channel_closed
+            .with_label_values(&["test-pinger"])
+            .inc();
+        metrics
+            .transaction_timeouts
+            .with_label_values(&["test-pinger"])
+            .inc();
+        metrics
+            .validators_app_send_failures
+            .with_label_values(&["test-pinger"])
+            .inc();
 
         encoder
             .encode(&metrics.registry.gather(), &mut buffer)
@@ -121,5 +198,10 @@ mod tests {
         let rendered = String::from_utf8(buffer).unwrap();
         assert!(rendered.contains("ping_thing_client_confirmation_latency"));
         assert!(rendered.contains("ping_thing_client_slot_latency"));
+        assert!(rendered.contains("ping_thing_client_watcher_up"));
+        assert!(rendered.contains("ping_thing_client_watcher_fatal_errors_total"));
+        assert!(rendered.contains("ping_thing_client_confirmation_channel_closed_total"));
+        assert!(rendered.contains("ping_thing_client_transaction_timeouts_total"));
+        assert!(rendered.contains("ping_thing_client_validators_app_send_failures_total"));
     }
 }

--- a/src/utils/slot.rs
+++ b/src/utils/slot.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use futures::StreamExt;
-use log::{error, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -27,7 +26,7 @@ impl GlobalSlotSent {
 
 /// Watches slot updates via gRPC subscription
 pub async fn watch_slot(
-    grpc_client: Arc<Mutex<GeyserGrpcClient<impl yellowstone_grpc_client::Interceptor + 'static>>>,
+    grpc_client: Arc<Mutex<GeyserGrpcClient>>,
     g_slot_sent: Arc<Mutex<GlobalSlotSent>>,
     _commitment: CommitmentLevel,
 ) -> Result<()> {
@@ -46,10 +45,10 @@ pub async fn watch_slot(
         ..Default::default()
     };
 
-    let (_subscribe_tx, mut stream) = {
+    let mut stream = {
         let mut client = grpc_client.lock().await;
         client
-            .subscribe_with_request(Some(subscribe_request))
+            .subscribe_once(subscribe_request)
             .await
             .context("Failed to create slot subscription")?
     };
@@ -89,20 +88,17 @@ pub async fn watch_slot(
                 }
             }
             Err(e) => {
-                error!(
-                    "[Slot Watcher] Error in stream (message #{:?}): {:?}",
-                    message_count, e
-                );
-                // Stream error - will need to reconnect
-                break;
+                return Err(anyhow::anyhow!(
+                    "[Slot Watcher] Fatal stream error after {:?} messages: {:?}",
+                    message_count,
+                    e
+                ));
             }
         }
     }
 
-    warn!(
+    Err(anyhow::anyhow!(
         "[Slot Watcher] Stream ended after processing {:?} messages",
         message_count
-    );
-
-    Ok(())
+    ))
 }

--- a/src/utils/subscription_manager.rs
+++ b/src/utils/subscription_manager.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use futures::StreamExt;
-use log::{error, info};
+use log::info;
 use solana_pubkey::Pubkey;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ use yellowstone_grpc_proto::prelude::{
 /// Watches all transactions for a specific wallet pubkey via gRPC subscription
 /// Sends (signature, slot_landed, confirmed) tuples through the channel
 pub async fn watch_transactions(
-    grpc_client: Arc<Mutex<GeyserGrpcClient<impl yellowstone_grpc_client::Interceptor + 'static>>>,
+    grpc_client: Arc<Mutex<GeyserGrpcClient>>,
     tx_updates_tx: mpsc::Sender<(String, u64, bool)>,
     wallet_pubkey: Pubkey,
     commitment: CommitmentLevel,
@@ -30,11 +30,12 @@ pub async fn watch_transactions(
         "wallet_transactions".to_string(),
         SubscribeRequestFilterTransactions {
             vote: Some(false),
-            failed: Some(false), // Include both successful and failed transactions
-            signature: None,     // Watch all transactions, not a specific one
+            failed: Some(false),
+            signature: None, // Watch all transactions, not a specific one
             account_include: vec![wallet_pubkey.to_string()],
             account_exclude: vec![],
             account_required: vec![wallet_pubkey.to_string()],
+            token_accounts: None,
         },
     );
 
@@ -44,10 +45,10 @@ pub async fn watch_transactions(
         ..Default::default()
     };
 
-    let (_subscribe_tx, mut stream) = {
+    let mut stream = {
         let mut client = grpc_client.lock().await;
         client
-            .subscribe_with_request(Some(subscribe_request))
+            .subscribe_once(subscribe_request)
             .await
             .context("Failed to create transaction subscription")?
     };
@@ -81,22 +82,28 @@ pub async fn watch_transactions(
                             ))
                             .await
                         {
-                            error!(
+                            return Err(anyhow::anyhow!(
                                 "[Transaction Watcher] Failed to send transaction update for signature {:?}, slot {:?}, confirmed {:?}: {:?}",
-                                tx_signature, slot_landed, confirmed, e
-                            );
+                                tx_signature,
+                                slot_landed,
+                                confirmed,
+                                e
+                            ));
                         }
                     }
                 }
             }
             Err(e) => {
-                error!(
-                    "[Transaction Watcher] Stream error for wallet {:?}: {:?}",
-                    wallet_pubkey, e
-                );
-                break;
+                return Err(anyhow::anyhow!(
+                    "[Transaction Watcher] Fatal stream error for wallet {:?}: {:?}",
+                    wallet_pubkey,
+                    e
+                ));
             }
         }
     }
-    Ok(())
+    Err(anyhow::anyhow!(
+        "[Transaction Watcher] Stream ended for wallet {:?}",
+        wallet_pubkey
+    ))
 }


### PR DESCRIPTION
  - Enabled Yellowstone auto reconnect with ReconnectConfig::default() in src/utils/grpc_client.rs.
  - Switched transaction, slot, and blockhash streams to subscribe_once(...).
  - Made stream errors and stream end paths return errors instead of silently ending.
  - Made a closed transaction update channel fatal in src/main.rs, so the app stops instead of sending more txs with no watcher.
  - Added Prometheus signals for watcher health, watcher fatal errors, closed confirmation channel, tx timeouts, and Validators.app send failures.
  - Reused one Validators.app HTTP client and added 3 send attempts.
  - Used TX_CONFIRMATION_TIMEOUT instead of the hard-coded 20 seconds.
  - Fixed the broken extra text in rust-toolchain.toml.